### PR TITLE
Fix typo on the homepage

### DIFF
--- a/django_toronto/templates/homepage.html
+++ b/django_toronto/templates/homepage.html
@@ -84,7 +84,7 @@
             <div class="span9">
                 <div class="alert alert-block">
                     <h3>Coming soon.</h3>
-                    Do you do Django/Python development? Do you need developers? Contact use to see how you can post your job here!
+                    Do you do Django/Python development? Do you need developers? Contact us to see how you can post your job here!
                 </div>
             </div>
         </div>


### PR DESCRIPTION
On the homepage 'Contact use' --> 'Contact us'
