### PR TITLE
Get rid of visibility: hidden on logo

### DIFF
--- a/django_toronto/static-media/css/base.css
+++ b/django_toronto/static-media/css/base.css
@@ -19,15 +19,14 @@ body {
 }
 */
 
-
 #top-bar {
     border-bottom: 1px solid #E0E0E0;
-
 }
 
 #home-logo {
     transition: opacity 0.5s linear;
     -webkit-transition: opacity 0.5s linear;
+    visibility: visible;
 }
 
 #top-bar .navbar-inner {


### PR DESCRIPTION
This fixes the logo fading out nicely, but snapping back in without
a transition when you scroll back up.

[Example](http://cl.ly/0k310l1K0J1a0t3U053B)
