### PR TITLE
Fix nav links falling into hero image

### DIFF
--- a/django_toronto/templates/_homepage_navigation.html
+++ b/django_toronto/templates/_homepage_navigation.html
@@ -1,14 +1,14 @@
 <div id='top-bar' class="navbar navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-        <a id="home-logo" href='{% url home %}' class="invisible">
-            <img src='{{ STATIC_URL }}images/logos/logo-small.png'>
-        </a>
         <ul class="nav">
           <li><a href="#nav-next-meetup">Next Meetup</a></li>
           <li><a href="#nav-presentations">Presentations</a></li>
           <li><a href="#nav-careers">Careers</a></li>
         </ul>
+        <a id="home-logo" href='{% url home %}' class="invisible">
+            <img src='{{ STATIC_URL }}images/logos/logo-small.png'>
+        </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Move the nav links list before the home image in the dom - it was a
floating issue.
